### PR TITLE
Allow per-conf specializations for specific markdown files

### DIFF
--- a/call-for-proposals.md
+++ b/call-for-proposals.md
@@ -41,19 +41,15 @@ https://{{conf-hostname}}
 ### Event Description
 
 
-{{conf-name}} is a comprehensive conference on {{conf-lang}} programming that started in {{conf-first-year}}, organized by developers for developers.
-Since 2022, we have held {{conf-name}} and {{other-conf-name}} as a co-located conference, but this year they are back-to-back with a 1-day overlap.
-It is organized by Develer, a software company based in Florence, Italy.
+**{{conf-name}}** is a comprehensive conference on **{{conf-lang}}** programming that started in {{conf-first-year}}, organized by **Develer**, a software company based in Florence, Italy. Designed by developers for developers, {{conf-name}} brings together experts and enthusiasts to share knowledge and innovation.
 
-{{conf-name}} will be an **in-person event**. In this edition you will find talks and workshops.
+{{conf-name}} will be an **in-person event**. In this edition you will find **talks** and workshops.
 
-We'll have two types of talks, a shorter one, the **25 min Discovery** talk, and a longer one, the **40 min Deep-dive** talk.
+**Talks** will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
 
-The Discovery talk is for the speaker who has found something cool and wants to share it with the world and inspire other developers.
+They are structured in 30 mins talk + 10 additional minutes for a Q/A session + 5 minutes to switch rooms. Speakers can modify the ratio between the talk and the Q/A session as they like. 
 
-Instead, the Deep-dive talk is intended to present and explain a topic in which the speaker is an expert. 
-
-The workshops are 3 hours long and focus on practical case studies.
+**Workshops** can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
 
 ---
 
@@ -88,18 +84,19 @@ No
 
 ### Call for Proposals
 
-{{conf-name}} is a comprehensive conference on the {{conf-lang}} programming language, established in 2015 and organized by Develer, a software company based in Florence, Italy. Designed by developers for developers, {{conf-name}} brings together experts and enthusiasts to share knowledge and innovation.
+**{{conf-name}}** is a comprehensive conference on **{{conf-lang}}** programming that started in {{conf-first-year}}, organized by **Develer**, a software company based in Florence, Italy. Designed by developers for developers, {{conf-name}} brings together experts and enthusiasts to share knowledge and innovation.
 
-{{conf-name}} will be an in-person event. In this edition you will find talks and workshops.
+{{conf-name}} will be an **in-person event**. In this edition you will find **talks** and workshops.
 
 
 ## Talks
 
-Talks will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
+**Talks** will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
+
 They are structured in 30 mins talk + 10 additional minutes for a Q/A session + 5 minutes to switch rooms. Speakers can modify the ratio between the talk and the Q/A session as they like. 
 
 ## Workshops
-Workshops can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
+**Workshops** can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
 
 
 ## Topics
@@ -113,7 +110,7 @@ Even if your talk is not strictly {{conf-lang}}-related, we encourage you to sub
 
 ## Language
 
-All presentations will be in English.
+All presentations will be in **English**.
 
 ## Content Guidelines
 
@@ -121,20 +118,22 @@ We would like our speakers to present **original content**. If your talk has bee
 
 We expect a common baseline of respectful tone from everyone (see the Code of Conduct for more details).
 
-Presenters can include a company logo **on the introduction slide only**. Talks about commercial products are allowed as long as they focus on the technical aspect.
-If you would like to speak about your company's product with more freedom, please consider giving a **sponsored talk**. You can contact us for more information at sponsors@{{conf-hostname}}.
+Presenters **can include a company logo on the introduction slide only**. Talks about commercial products are allowed as long as they focus on the technical aspect.
+
+If you would like to speak about your company's product with more freedom, please consider giving a **sponsored talk**. You can contact us for more information at [sponsors@{{conf-hostname}}](mailto:sponsors@{{conf-hostname}}).
 
 Given that we have only one slot per day allocated for sponsored talks, please consider that the likelihood of your sponsored talk being featured on the schedule is lower than that of a regular talk.
 
-We welcome first-time speakers
+### After you have sent your proposal
+
+We'll review your proposal as soon as possible and give you some feedback.
+
+### We welcome first-time speakers
 
 In the coming months, we will offer weekly online office hours for all accepted speakers, where you can talk to us and ask your questions directly.
 
-We will offer 1 to 1 rehearsals, either online or in person at the Develer offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
+We will offer 1 to 1 rehearsals, either online or in person at the **Develer** offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
 
-After you have sent your proposal
-
-We'll review your proposal as soon as possible and give you some feedback.
 
 
 ## General advice
@@ -150,27 +149,31 @@ Please not too long: it would be nice if it could fit in a tweet.
 Remember also that the schedule should be readable on smartphones too.
 
 _[kind of session]_
-The kind of session your presentation can apply to (choose among talk, half-day workshop or whole-day workshop)
+The kind of session your presentation can apply to (choose among *talk*, *half-day workshop* or *whole-day workshop*)
 
 _[level]_
-Please specify the level of the audience your presentation is addressed to (choose from Introductory and Overview, Intermediate, Advanced and Expert)
+Please specify the level of the audience your presentation is addressed to (choose from *Introductory and Overview*, *Intermediate*, *Advanced* and *Expert*)
 
 _[abstract]_
 This is how your session will be described to the attendees in our schedule. So please be concise on what you are talking about but also try to spice up the interest of your audience by giving them evaluable reasons to attend your presentation.
 
-In case you are making a proposal for a workshop, you may want to specify some technical requirements that your audience should meet to ensure a satisfying experience, such as some devices (a laptop) or a certain version of some software installed on their computer.
+In case you are making a proposal for a workshop, you may want to specify some **technical requirements** that your audience should meet to ensure a satisfying experience, such as some devices (a laptop) or a certain version of some software installed on their computer.
 
 
 ## Ticketing
 
-If you submit a talk or workshop proposal you will be allowed to get your ticket at Early Bird price. In case your proposal may be rejected, we will send you a **discount code to get a Regular ticket for the price of an Early Bird one**. Please make sure to **purchase your ticket before the Regular fare deadline** (September 15th, 2025, at 12 PM, CET) otherwise the discount code won’t apply properly!
+Submitting a talk or workshop proposal allows you to get an Early Bird ticket price. If your proposal is rejected, we’ll send you a **discount code to buy a Regular ticket at the Early Bird price.** Please make sure to **purchase your ticket before the Regular fare deadline ({{regular-fare-deadline}})** otherwise the discount code won’t apply properly!
 
+Of course, in case you'll be appointed as a speaker, you'll get a **free Speaker ticket** which is equivalent of a **Premium** one. In case you already bought a ticket for the conference you may choose between reassigning that ticket to somebody else or have it refunded.
+
+This year GoLab and Rustlab will be held together (same days in the same venue), so **your ticket will be valid to attend both conferences** as well!
 
 
 
 ## **IMPORTANT: Visa documentation**
 
-According to the Italian Laws, **we are not authorized to produce a document in support of people requesting a business visa for coming to speak to our conferences**. You must request a simple touristic visa and the only document we can produce in support is a declaration you will attend our conference and you will stay in the venue hotel in the conference period.
+According to the Italian Laws, **we are not authorized to produce a document in support of people requesting a business visa for coming to speak to our conferences**. You must request a simple **touristic visa** and the only document we can produce in support is a declaration you will attend our conference and you will stay in the venue hotel in the conference period.
+
 Please check if you can get your visa in your country in time for the conference before submitting your proposal.
 
 
@@ -178,10 +181,13 @@ Please check if you can get your visa in your country in time for the conference
 
 If your talk is accepted, congrats: you will be officially a {{conf-name}} 2026 speaker! 
 
-This grants you a free **Premium ticket** for the {{conf-name}} conference as well as for {{other-conf-name}} (free access to all talks and workshops) and free access to the social dinner.
+This grants you a **free Speaker ticket** for the conference (free access to all talks and workshops) and free access to the social dinner.
 
-Plus, we also offer a room at the Grand Hotel Mediterraneo ({{conf-name}}’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
+Plus, we also offer **a room'* at the {{conf-venue}} ({{conf-name}}’s venue) for all the conference duration** (2 nights for talks, 3 nights for workshops presenters).
 
-We regret that **we can only cover accommodation**; travel expenses are not reimbursed.
+We regret that _**we can only cover accommodation**_; travel expenses are not reimbursed.
+
+'* = the room we offer is a double room for a single use. In case you need different requirements, please e-mail us at [info@{{conf-hostname}}](mailto:info@{{conf-hostname}}) and we will help you out to meet them. This will be the lodging offer covered by the conference organization anyway: in case of further extras (more nights, bigger room, etc.) they will be on your charge.
 
 Let's have a great conference together!
+

--- a/call-for-proposals.md
+++ b/call-for-proposals.md
@@ -76,7 +76,7 @@ ALL REPORTS ARE CONFIDENTIAL.
 
 ---
 
-15 Mar 2024 12:00 am - 05 May 2024 11:59 pm (Italy local time)
+{{cfp-open-close-date}}
 
 ---
 
@@ -86,54 +86,28 @@ No
 
 ---
 
-### CFP Description
+### Call for Proposals
 
-While we are open to considering any application, we would like our speakers to present **original content**.
+{{conf-name}} is a comprehensive conference on the {{conf-lang}} programming language, established in 2015 and organized by Develer, a software company based in Florence, Italy. Designed by developers for developers, {{conf-name}} brings together experts and enthusiasts to share knowledge and innovation.
 
-We will accept the following types of talks:
+{{conf-name}} will be an in-person event. In this edition you will find talks and workshops.
 
-
-* 25 min - Discovery talks
-* 40 min - Deep-dive talks
-* 3 hours - Workshops
 
 ## Talks
 
-The **Discovery talk** is for the speaker who has found something cool and wants to share it with the world and inspire other developers. There is no question time in this format.
+Talks will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
+They are structured in 30 mins talk + 10 additional minutes for a Q/A session + 5 minutes to switch rooms. Speakers can modify the ratio between the talk and the Q/A session as they like. 
 
-Instead, the **Deep-dive talk** is intended to present and explain a topic that the presenter is an expert on and/or wants to share in more detail. The presenter can use the entire time for the talk or reserve a few minutes for questions.
+## Workshops
+Workshops can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
 
-## Workshop
-
-A workshop is more hands-on. The presenter can engage the audience in a hands-on tutorial on a topic/technology. Attendees may be asked to set up their environment in advance.
-
-We expect at least 20 people to attend all workshops.
 
 ## Topics
 
-{{conf-name}} is open to any {{conf-lang}} related topic. Examples include cloud and networking, language and ecosystem, devices and platforms, security. Cross-topic proposals are also welcome.
+{{conf-name}} is receptive to proposals on any {{conf-lang}}-related subject matter, including but not limited to cloud computing, networking, programming languages, ecosystems, devices, platforms, and security. Additionally, we encourage submissions that span multiple topics.
 
-If you have a particularly interesting talk that doesn't fit into one of the suggested topics, feel free to submit it anyway and we'll be happy to consider it.
+Even if your talk is not strictly {{conf-lang}}-related, we encourage you to submit it. We welcome challenging and unconventional proposals!
 
-## We welcome first-time speakers.
-
-In the coming months, we will offer weekly online office hours for all accepted speakers, where you can talk to us and ask your questions directly.
-
-We will offer 1 to 1 rehearsals, either online or in person at the Develer offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
-
-## After you have sent your proposal
-
-We'll review your proposal as soon as possible and give you some feedback.
-
-Let's make a great conference together!
-
----
-
-### Additional Information
-
-Please, write us any special request or ask for clarification about anything.
-
----
 
 ### CFP Notes
 
@@ -143,48 +117,72 @@ All presentations will be in English.
 
 ## Content Guidelines
 
+We would like our speakers to present **original content**. If your talk has been presented at another conference, please indicate this in your submission.
+
 We expect a common baseline of respectful tone from everyone (see the Code of Conduct for more details).
 
-Presenters may include a company logo on the introduction slide only. Talks about commercial products are allowed as long as they focus on the technical aspect.
-
+Presenters can include a company logo **on the introduction slide only**. Talks about commercial products are allowed as long as they focus on the technical aspect.
 If you would like to speak about your company's product with more freedom, please consider giving a **sponsored talk**. You can contact us for more information at sponsors@{{conf-hostname}}.
 
+Given that we have only one slot per day allocated for sponsored talks, please consider that the likelihood of your sponsored talk being featured on the schedule is lower than that of a regular talk.
 
-### Which types of talks will you accept?
+We welcome first-time speakers
 
-- Discovery talk (25 min)
-- Deep-dive talk (40 min)
-- Workshop (3 hours)
+In the coming months, we will offer weekly online office hours for all accepted speakers, where you can talk to us and ask your questions directly.
 
+We will offer 1 to 1 rehearsals, either online or in person at the Develer offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
 
-### Tags
+After you have sent your proposal
 
-...
-
-## Travel
-
-### Do you offer travel assistance?
-
-No
-
----
-
-### If yes, what is your policy?
-
-Accepted speakers will have a reserved room at the venue hotel for the 2 days of the conference (3 days for workshop speakers). 
-
-## Environmental commitment
-
-We are focusing even more on our planet and the environmental emergency. Thanks to our partner [Treedom](https://www.treedom.net), we'll be growing a small forest as part of the {{conf-name}} + {{other-conf-name}} {{conf-year}} CO2 offsetting initiative.
+We'll review your proposal as soon as possible and give you some feedback.
 
 
-### Rating Style
+## General advice
+
+{{conf-name}} receives a lot of proposals, so the team must make a choice. We will review the proposals based on the selection criteria below, please ensure your talk or workshop meet all of them. 
+
+Write a presentation that is long enough to let us understand what’s the goal you want to achieve with the talk, that you have real practical experience on the topic, that you discovered new things that are valuable to share with the community. Moreover please ensure your proposal matches the conference topics and that you’re able to present your talk in the given time slot.
+
+A typical structure of your proposal may be:
+
+_[title/outline]_
+Please not too long: it would be nice if it could fit in a tweet.
+Remember also that the schedule should be readable on smartphones too.
+
+_[kind of session]_
+The kind of session your presentation can apply to (choose among talk, half-day workshop or whole-day workshop)
+
+_[level]_
+Please specify the level of the audience your presentation is addressed to (choose from Introductory and Overview, Intermediate, Advanced and Expert)
+
+_[abstract]_
+This is how your session will be described to the attendees in our schedule. So please be concise on what you are talking about but also try to spice up the interest of your audience by giving them evaluable reasons to attend your presentation.
+
+In case you are making a proposal for a workshop, you may want to specify some technical requirements that your audience should meet to ensure a satisfying experience, such as some devices (a laptop) or a certain version of some software installed on their computer.
 
 
-Five Star (scalar)
+## Ticketing
+
+If you submit a talk or workshop proposal you will be allowed to get your ticket at Early Bird price. In case your proposal may be rejected, we will send you a **discount code to get a Regular ticket for the price of an Early Bird one**. Please make sure to **purchase your ticket before the Regular fare deadline** (September 15th, 2025, at 12 PM, CET) otherwise the discount code won’t apply properly!
 
 
-### Profile Submission Settings
 
 
-no Shirt Size
+## **IMPORTANT: Visa documentation**
+
+According to the Italian Laws, **we are not authorized to produce a document in support of people requesting a business visa for coming to speak to our conferences**. You must request a simple touristic visa and the only document we can produce in support is a declaration you will attend our conference and you will stay in the venue hotel in the conference period.
+Please check if you can get your visa in your country in time for the conference before submitting your proposal.
+
+
+## Benefits for speakers
+
+If your talk is accepted, congrats: you will be officially a {{conf-name}} 2026 speaker! 
+
+This grants you a free **Premium ticket** for the conference (free access to all talks and workshops) and free access to the social dinner.
+[1] Plus, we also offer a room at the Grand Hotel Mediterraneo ({{conf-name}}’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
+
+We regret that **we can only cover accommodation**; travel expenses are not reimbursed.
+
+
+
+Let's have a great conference together!

--- a/call-for-proposals.md
+++ b/call-for-proposals.md
@@ -41,7 +41,7 @@ https://{{conf-hostname}}
 ### Event Description
 
 
-{{conf-name}} is a comprehensive conference on {{conf-lang}} programming that started in {{conf-fist-year}}, organized by developers for developers.
+{{conf-name}} is a comprehensive conference on {{conf-lang}} programming that started in {{conf-first-year}}, organized by developers for developers.
 Since 2022, we have held {{conf-name}} and {{other-conf-name}} as a co-located conference, but this year they are back-to-back with a 1-day overlap.
 It is organized by Develer, a software company based in Florence, Italy.
 
@@ -178,11 +178,10 @@ Please check if you can get your visa in your country in time for the conference
 
 If your talk is accepted, congrats: you will be officially a {{conf-name}} 2026 speaker! 
 
-This grants you a free **Premium ticket** for the conference (free access to all talks and workshops) and free access to the social dinner.
-[1] Plus, we also offer a room at the Grand Hotel Mediterraneo ({{conf-name}}’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
+This grants you a free **Premium ticket** for the {{conf-name}} conference as well as for {{other-conf-name}} (free access to all talks and workshops) and free access to the social dinner.
+
+Plus, we also offer a room at the Grand Hotel Mediterraneo ({{conf-name}}’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
 
 We regret that **we can only cover accommodation**; travel expenses are not reimbursed.
-
-
 
 Let's have a great conference together!

--- a/generate.py
+++ b/generate.py
@@ -9,10 +9,12 @@ base = {
     "conf-staff-list": """
 - Mena Marotta (she/her)
 - Matteo Bertini (he/him)
-- Niccolò Pieretti (he/him)
+- Aurélien Rainone (he/him)
+- Federico Guerinoni (he/him)
+- Pietro Lorefice (he/him)
 """,
-    "conf-year": "2024",
-    "conf-location": "Florence, Italy",
+    "conf-year": "2026",
+    "conf-location": "Bologna, Italy",
 }
 
 conf_data = {
@@ -20,38 +22,60 @@ conf_data = {
         "conf-name": "GoLab",
         "conf-hostname": "golab.io",
         "conf-lang": "Go",
-        "conf-fist-year": "2015",
-        "conf-dates": "November 11-13",
+        "conf-first-year": "2015",
+        "conf-dates": "November 1-3",
+        "cfp-open-close-date": "27 Feb 2026 12:00 am - 13 Apr 2026 11:59 pm (Italy local time)",
     },
     "rustlab": {
         "conf-name": "RustLab",
         "conf-hostname": "rustlab.it",
         "conf-lang": "Rust",
-        "conf-fist-year": "2019",
-        "conf-dates": "November 9-11",
+        "conf-first-year": "2019",
+        "conf-dates": "November 1-3",
+        "cfp-open-close-date": "27 Feb 2026 12:00 am - 13 Apr 2026 11:59 pm (Italy local time)",
     },
 }
 
 for conf in conf_data:
-    conf_data[conf]["conf-slug"] = conf+'-'+base["conf-year"]
+    conf_data[conf]["conf-slug"] = conf + "-" + base["conf-year"]
 
 for this, other in [("golab", "rustlab"), ("rustlab", "golab")]:
     for key in list(conf_data[this]):
         if key.startswith("conf-"):
-             conf_data[this]["other-"+key] = conf_data[other][key]
+            conf_data[this]["other-" + key] = conf_data[other][key]
 
 
 def generate(conf):
     os.makedirs(conf, exist_ok=True)
     for md in glob.glob("*.md"):
+        oname = md
+
+        # Look for conference-specific files
+        splits = md.split(".")
+        if len(splits) not in [2, 3]:
+            print(f"does not support filenames with . such as {md}")
+            sys.exit(1)
+
+        if len(splits) == 3:
+            if splits[0] != conf:
+                print(f"skipping {md}")
+                continue
+            oname = ".".join(splits[1:])
+
         with open(md) as template:
             data = template.read()
             for key, value in (base | conf_data[conf]).items():
                 data = data.replace("{{%s}}" % key, value)
-        with open(os.path.join(conf, md), "w+") as target:
+        opath = os.path.join(conf, oname)
+        with open(opath, "w+") as target:
             target.write(data)
+            print(f"written {opath}")
 
 
 if __name__ == "__main__":
-    generate("golab")
-    generate("rustlab")
+    import sys
+
+    if len(sys.argv) != 2 or sys.argv[1] not in ["golab", "rustlab"]:
+        print("usage: generate.py golab|rustlab")
+        sys.exit(1)
+    generate(sys.argv[1])

--- a/golab/call-for-proposals.md
+++ b/golab/call-for-proposals.md
@@ -1,11 +1,11 @@
-# GoLab 2024 Call For Proposals
+# GoLab 2026 Call For Proposals
 
 ## Event Details
 
 ### Event Name
 
 
-GoLab 2024
+GoLab 2026
 
 
 ---
@@ -13,7 +13,7 @@ GoLab 2024
 ### Event Slug
 
 
-https://sessionize.com/golab-2024
+https://sessionize.com/golab-2026
 
 ---
 
@@ -27,14 +27,14 @@ https://golab.io
 ### Event Location
 
 
-Florence, Italy
+Bologna, Italy
 
 ---
 
 ### Event Dates
 
 
-November 11-13, 2024
+November 1-3, 2026
 
 ---
 
@@ -76,7 +76,7 @@ ALL REPORTS ARE CONFIDENTIAL.
 
 ---
 
-15 Mar 2024 12:00 am - 05 May 2024 11:59 pm (Italy local time)
+27 Feb 2026 12:00 am - 13 Apr 2026 11:59 pm (Italy local time)
 
 ---
 
@@ -86,54 +86,28 @@ No
 
 ---
 
-### CFP Description
+### Call for Proposals
 
-While we are open to considering any application, we would like our speakers to present **original content**.
+GoLab is a comprehensive conference on the Go programming language, established in 2015 and organized by Develer, a software company based in Bologna, Italy. Designed by developers for developers, GoLab brings together experts and enthusiasts to share knowledge and innovation.
 
-We will accept the following types of talks:
+GoLab will be an in-person event. In this edition you will find talks and workshops.
 
-
-* 25 min - Discovery talks
-* 40 min - Deep-dive talks
-* 3 hours - Workshops
 
 ## Talks
 
-The **Discovery talk** is for the speaker who has found something cool and wants to share it with the world and inspire other developers. There is no question time in this format.
+Talks will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
+They are structured in 30 mins talk + 10 additional minutes for a Q/A session + 5 minutes to switch rooms. Speakers can modify the ratio between the talk and the Q/A session as they like. 
 
-Instead, the **Deep-dive talk** is intended to present and explain a topic that the presenter is an expert on and/or wants to share in more detail. The presenter can use the entire time for the talk or reserve a few minutes for questions.
+## Workshops
+Workshops can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
 
-## Workshop
-
-A workshop is more hands-on. The presenter can engage the audience in a hands-on tutorial on a topic/technology. Attendees may be asked to set up their environment in advance.
-
-We expect at least 20 people to attend all workshops.
 
 ## Topics
 
-GoLab is open to any Go related topic. Examples include cloud and networking, language and ecosystem, devices and platforms, security. Cross-topic proposals are also welcome.
+GoLab is receptive to proposals on any Go-related subject matter, including but not limited to cloud computing, networking, programming languages, ecosystems, devices, platforms, and security. Additionally, we encourage submissions that span multiple topics.
 
-If you have a particularly interesting talk that doesn't fit into one of the suggested topics, feel free to submit it anyway and we'll be happy to consider it.
+Even if your talk is not strictly Go-related, we encourage you to submit it. We welcome challenging and unconventional proposals!
 
-## We welcome first-time speakers.
-
-In the coming months, we will offer weekly online office hours for all accepted speakers, where you can talk to us and ask your questions directly.
-
-We will offer 1 to 1 rehearsals, either online or in person at the Develer offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
-
-## After you have sent your proposal
-
-We'll review your proposal as soon as possible and give you some feedback.
-
-Let's make a great conference together!
-
----
-
-### Additional Information
-
-Please, write us any special request or ask for clarification about anything.
-
----
 
 ### CFP Notes
 
@@ -143,48 +117,72 @@ All presentations will be in English.
 
 ## Content Guidelines
 
+We would like our speakers to present **original content**. If your talk has been presented at another conference, please indicate this in your submission.
+
 We expect a common baseline of respectful tone from everyone (see the Code of Conduct for more details).
 
-Presenters may include a company logo on the introduction slide only. Talks about commercial products are allowed as long as they focus on the technical aspect.
-
+Presenters can include a company logo **on the introduction slide only**. Talks about commercial products are allowed as long as they focus on the technical aspect.
 If you would like to speak about your company's product with more freedom, please consider giving a **sponsored talk**. You can contact us for more information at sponsors@golab.io.
 
+Given that we have only one slot per day allocated for sponsored talks, please consider that the likelihood of your sponsored talk being featured on the schedule is lower than that of a regular talk.
 
-### Which types of talks will you accept?
+We welcome first-time speakers
 
-- Discovery talk (25 min)
-- Deep-dive talk (40 min)
-- Workshop (3 hours)
+In the coming months, we will offer weekly online office hours for all accepted speakers, where you can talk to us and ask your questions directly.
 
+We will offer 1 to 1 rehearsals, either online or in person at the Develer offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
 
-### Tags
+After you have sent your proposal
 
-...
-
-## Travel
-
-### Do you offer travel assistance?
-
-No
-
----
-
-### If yes, what is your policy?
-
-Accepted speakers will have a reserved room at the venue hotel for the 2 days of the conference (3 days for workshop speakers). 
-
-## Environmental commitment
-
-We are focusing even more on our planet and the environmental emergency. Thanks to our partner [Treedom](https://www.treedom.net), we'll be growing a small forest as part of the GoLab + RustLab 2024 CO2 offsetting initiative.
+We'll review your proposal as soon as possible and give you some feedback.
 
 
-### Rating Style
+## General advice
+
+GoLab receives a lot of proposals, so the team must make a choice. We will review the proposals based on the selection criteria below, please ensure your talk or workshop meet all of them. 
+
+Write a presentation that is long enough to let us understand what’s the goal you want to achieve with the talk, that you have real practical experience on the topic, that you discovered new things that are valuable to share with the community. Moreover please ensure your proposal matches the conference topics and that you’re able to present your talk in the given time slot.
+
+A typical structure of your proposal may be:
+
+_[title/outline]_
+Please not too long: it would be nice if it could fit in a tweet.
+Remember also that the schedule should be readable on smartphones too.
+
+_[kind of session]_
+The kind of session your presentation can apply to (choose among talk, half-day workshop or whole-day workshop)
+
+_[level]_
+Please specify the level of the audience your presentation is addressed to (choose from Introductory and Overview, Intermediate, Advanced and Expert)
+
+_[abstract]_
+This is how your session will be described to the attendees in our schedule. So please be concise on what you are talking about but also try to spice up the interest of your audience by giving them evaluable reasons to attend your presentation.
+
+In case you are making a proposal for a workshop, you may want to specify some technical requirements that your audience should meet to ensure a satisfying experience, such as some devices (a laptop) or a certain version of some software installed on their computer.
 
 
-Five Star (scalar)
+## Ticketing
+
+If you submit a talk or workshop proposal you will be allowed to get your ticket at Early Bird price. In case your proposal may be rejected, we will send you a **discount code to get a Regular ticket for the price of an Early Bird one**. Please make sure to **purchase your ticket before the Regular fare deadline** (September 15th, 2025, at 12 PM, CET) otherwise the discount code won’t apply properly!
 
 
-### Profile Submission Settings
 
 
-no Shirt Size
+## **IMPORTANT: Visa documentation**
+
+According to the Italian Laws, **we are not authorized to produce a document in support of people requesting a business visa for coming to speak to our conferences**. You must request a simple touristic visa and the only document we can produce in support is a declaration you will attend our conference and you will stay in the venue hotel in the conference period.
+Please check if you can get your visa in your country in time for the conference before submitting your proposal.
+
+
+## Benefits for speakers
+
+If your talk is accepted, congrats: you will be officially a GoLab 2026 speaker! 
+
+This grants you a free **Premium ticket** for the conference (free access to all talks and workshops) and free access to the social dinner.
+[1] Plus, we also offer a room at the Grand Hotel Mediterraneo (GoLab’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
+
+We regret that **we can only cover accommodation**; travel expenses are not reimbursed.
+
+
+
+Let's have a great conference together!

--- a/golab/call-for-proposals.md
+++ b/golab/call-for-proposals.md
@@ -88,7 +88,7 @@ No
 
 ### Call for Proposals
 
-GoLab is a comprehensive conference on the Go programming language, established in 2015 and organized by Develer, a software company based in Bologna, Italy. Designed by developers for developers, GoLab brings together experts and enthusiasts to share knowledge and innovation.
+GoLab is a comprehensive conference on the Go programming language, established in 2015 and organized by Develer, a software company based in Florence, Italy. Designed by developers for developers, GoLab brings together experts and enthusiasts to share knowledge and innovation.
 
 GoLab will be an in-person event. In this edition you will find talks and workshops.
 
@@ -178,11 +178,10 @@ Please check if you can get your visa in your country in time for the conference
 
 If your talk is accepted, congrats: you will be officially a GoLab 2026 speaker! 
 
-This grants you a free **Premium ticket** for the conference (free access to all talks and workshops) and free access to the social dinner.
-[1] Plus, we also offer a room at the Grand Hotel Mediterraneo (GoLab’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
+This grants you a free **Premium ticket** for the GoLab conference as well as for RustLab (free access to all talks and workshops) and free access to the social dinner.
+
+Plus, we also offer a room at the Grand Hotel Mediterraneo (GoLab’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
 
 We regret that **we can only cover accommodation**; travel expenses are not reimbursed.
-
-
 
 Let's have a great conference together!

--- a/golab/call-for-proposals.md
+++ b/golab/call-for-proposals.md
@@ -41,19 +41,15 @@ November 1-3, 2026
 ### Event Description
 
 
-GoLab is a comprehensive conference on Go programming that started in 2015, organized by developers for developers.
-Since 2022, we have held GoLab and RustLab as a co-located conference, but this year they are back-to-back with a 1-day overlap.
-It is organized by Develer, a software company based in Florence, Italy.
+**GoLab** is a comprehensive conference on **Go** programming that started in 2015, organized by **Develer**, a software company based in Florence, Italy. Designed by developers for developers, GoLab brings together experts and enthusiasts to share knowledge and innovation.
 
-GoLab will be an **in-person event**. In this edition you will find talks and workshops.
+GoLab will be an **in-person event**. In this edition you will find **talks** and workshops.
 
-We'll have two types of talks, a shorter one, the **25 min Discovery** talk, and a longer one, the **40 min Deep-dive** talk.
+**Talks** will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
 
-The Discovery talk is for the speaker who has found something cool and wants to share it with the world and inspire other developers.
+They are structured in 30 mins talk + 10 additional minutes for a Q/A session + 5 minutes to switch rooms. Speakers can modify the ratio between the talk and the Q/A session as they like. 
 
-Instead, the Deep-dive talk is intended to present and explain a topic in which the speaker is an expert. 
-
-The workshops are 3 hours long and focus on practical case studies.
+**Workshops** can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
 
 ---
 
@@ -88,18 +84,19 @@ No
 
 ### Call for Proposals
 
-GoLab is a comprehensive conference on the Go programming language, established in 2015 and organized by Develer, a software company based in Florence, Italy. Designed by developers for developers, GoLab brings together experts and enthusiasts to share knowledge and innovation.
+**GoLab** is a comprehensive conference on **Go** programming that started in 2015, organized by **Develer**, a software company based in Florence, Italy. Designed by developers for developers, GoLab brings together experts and enthusiasts to share knowledge and innovation.
 
-GoLab will be an in-person event. In this edition you will find talks and workshops.
+GoLab will be an **in-person event**. In this edition you will find **talks** and workshops.
 
 
 ## Talks
 
-Talks will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
+**Talks** will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
+
 They are structured in 30 mins talk + 10 additional minutes for a Q/A session + 5 minutes to switch rooms. Speakers can modify the ratio between the talk and the Q/A session as they like. 
 
 ## Workshops
-Workshops can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
+**Workshops** can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
 
 
 ## Topics
@@ -113,7 +110,7 @@ Even if your talk is not strictly Go-related, we encourage you to submit it. We 
 
 ## Language
 
-All presentations will be in English.
+All presentations will be in **English**.
 
 ## Content Guidelines
 
@@ -121,20 +118,22 @@ We would like our speakers to present **original content**. If your talk has bee
 
 We expect a common baseline of respectful tone from everyone (see the Code of Conduct for more details).
 
-Presenters can include a company logo **on the introduction slide only**. Talks about commercial products are allowed as long as they focus on the technical aspect.
-If you would like to speak about your company's product with more freedom, please consider giving a **sponsored talk**. You can contact us for more information at sponsors@golab.io.
+Presenters **can include a company logo on the introduction slide only**. Talks about commercial products are allowed as long as they focus on the technical aspect.
+
+If you would like to speak about your company's product with more freedom, please consider giving a **sponsored talk**. You can contact us for more information at [sponsors@golab.io](mailto:sponsors@golab.io).
 
 Given that we have only one slot per day allocated for sponsored talks, please consider that the likelihood of your sponsored talk being featured on the schedule is lower than that of a regular talk.
 
-We welcome first-time speakers
+### After you have sent your proposal
+
+We'll review your proposal as soon as possible and give you some feedback.
+
+### We welcome first-time speakers
 
 In the coming months, we will offer weekly online office hours for all accepted speakers, where you can talk to us and ask your questions directly.
 
-We will offer 1 to 1 rehearsals, either online or in person at the Develer offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
+We will offer 1 to 1 rehearsals, either online or in person at the **Develer** offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
 
-After you have sent your proposal
-
-We'll review your proposal as soon as possible and give you some feedback.
 
 
 ## General advice
@@ -150,27 +149,31 @@ Please not too long: it would be nice if it could fit in a tweet.
 Remember also that the schedule should be readable on smartphones too.
 
 _[kind of session]_
-The kind of session your presentation can apply to (choose among talk, half-day workshop or whole-day workshop)
+The kind of session your presentation can apply to (choose among *talk*, *half-day workshop* or *whole-day workshop*)
 
 _[level]_
-Please specify the level of the audience your presentation is addressed to (choose from Introductory and Overview, Intermediate, Advanced and Expert)
+Please specify the level of the audience your presentation is addressed to (choose from *Introductory and Overview*, *Intermediate*, *Advanced* and *Expert*)
 
 _[abstract]_
 This is how your session will be described to the attendees in our schedule. So please be concise on what you are talking about but also try to spice up the interest of your audience by giving them evaluable reasons to attend your presentation.
 
-In case you are making a proposal for a workshop, you may want to specify some technical requirements that your audience should meet to ensure a satisfying experience, such as some devices (a laptop) or a certain version of some software installed on their computer.
+In case you are making a proposal for a workshop, you may want to specify some **technical requirements** that your audience should meet to ensure a satisfying experience, such as some devices (a laptop) or a certain version of some software installed on their computer.
 
 
 ## Ticketing
 
-If you submit a talk or workshop proposal you will be allowed to get your ticket at Early Bird price. In case your proposal may be rejected, we will send you a **discount code to get a Regular ticket for the price of an Early Bird one**. Please make sure to **purchase your ticket before the Regular fare deadline** (September 15th, 2025, at 12 PM, CET) otherwise the discount code won’t apply properly!
+Submitting a talk or workshop proposal allows you to get an Early Bird ticket price. If your proposal is rejected, we’ll send you a **discount code to buy a Regular ticket at the Early Bird price.** Please make sure to **purchase your ticket before the Regular fare deadline ({{regular-fare-deadline}})** otherwise the discount code won’t apply properly!
 
+Of course, in case you'll be appointed as a speaker, you'll get a **free Speaker ticket** which is equivalent of a **Premium** one. In case you already bought a ticket for the conference you may choose between reassigning that ticket to somebody else or have it refunded.
+
+This year GoLab and Rustlab will be held together (same days in the same venue), so **your ticket will be valid to attend both conferences** as well!
 
 
 
 ## **IMPORTANT: Visa documentation**
 
-According to the Italian Laws, **we are not authorized to produce a document in support of people requesting a business visa for coming to speak to our conferences**. You must request a simple touristic visa and the only document we can produce in support is a declaration you will attend our conference and you will stay in the venue hotel in the conference period.
+According to the Italian Laws, **we are not authorized to produce a document in support of people requesting a business visa for coming to speak to our conferences**. You must request a simple **touristic visa** and the only document we can produce in support is a declaration you will attend our conference and you will stay in the venue hotel in the conference period.
+
 Please check if you can get your visa in your country in time for the conference before submitting your proposal.
 
 
@@ -178,10 +181,13 @@ Please check if you can get your visa in your country in time for the conference
 
 If your talk is accepted, congrats: you will be officially a GoLab 2026 speaker! 
 
-This grants you a free **Premium ticket** for the GoLab conference as well as for RustLab (free access to all talks and workshops) and free access to the social dinner.
+This grants you a **free Speaker ticket** for the conference (free access to all talks and workshops) and free access to the social dinner.
 
-Plus, we also offer a room at the Grand Hotel Mediterraneo (GoLab’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
+Plus, we also offer **a room'* at the {{conf-venue}} (GoLab’s venue) for all the conference duration** (2 nights for talks, 3 nights for workshops presenters).
 
-We regret that **we can only cover accommodation**; travel expenses are not reimbursed.
+We regret that _**we can only cover accommodation**_; travel expenses are not reimbursed.
+
+'* = the room we offer is a double room for a single use. In case you need different requirements, please e-mail us at [info@golab.io](mailto:info@golab.io) and we will help you out to meet them. This will be the lodging offer covered by the conference organization anyway: in case of further extras (more nights, bigger room, etc.) they will be on your charge.
 
 Let's have a great conference together!
+

--- a/golab/code_of_conduct.md
+++ b/golab/code_of_conduct.md
@@ -44,7 +44,9 @@ If the matter is especially urgent, please contact any of these individuals or e
 
 - Mena Marotta (she/her)
 - Matteo Bertini (he/him)
-- Niccolò Pieretti (he/him)
+- Aurélien Rainone (he/him)
+- Federico Guerinoni (he/him)
+- Pietro Lorefice (he/him)
 
 
 The code of conduct team is empowered to, amongst other things:

--- a/rustlab/call-for-proposals.md
+++ b/rustlab/call-for-proposals.md
@@ -1,11 +1,11 @@
-# RustLab 2024 Call For Proposals
+# RustLab 2026 Call For Proposals
 
 ## Event Details
 
 ### Event Name
 
 
-RustLab 2024
+RustLab 2026
 
 
 ---
@@ -13,7 +13,7 @@ RustLab 2024
 ### Event Slug
 
 
-https://sessionize.com/rustlab-2024
+https://sessionize.com/rustlab-2026
 
 ---
 
@@ -27,21 +27,21 @@ https://rustlab.it
 ### Event Location
 
 
-Florence, Italy
+Bologna, Italy
 
 ---
 
 ### Event Dates
 
 
-November 9-11, 2024
+November 1-3, 2026
 
 ---
 
 ### Event Description
 
 
-RustLab is a comprehensive conference on Rust programming that started in 2019, organized by developers for developers.
+RustLab is a comprehensive conference on Rust programming that started in 2015, organized by developers for developers.
 Since 2022, we have held RustLab and GoLab as a co-located conference, but this year they are back-to-back with a 1-day overlap.
 It is organized by Develer, a software company based in Florence, Italy.
 
@@ -76,7 +76,7 @@ ALL REPORTS ARE CONFIDENTIAL.
 
 ---
 
-15 Mar 2024 12:00 am - 05 May 2024 11:59 pm (Italy local time)
+27 Feb 2026 12:00 am - 13 Apr 2026 11:59 pm (Italy local time)
 
 ---
 
@@ -86,54 +86,28 @@ No
 
 ---
 
-### CFP Description
+### Call for Proposals
 
-While we are open to considering any application, we would like our speakers to present **original content**.
+RustLab is a comprehensive conference on the Go programming language, established in 2015 and organized by Develer, a software company based in Bologna, Italy. Designed by developers for developers, RustLab brings together experts and enthusiasts to share knowledge and innovation.
 
-We will accept the following types of talks:
+RustLab will be an in-person event. In this edition you will find talks and workshops.
 
-
-* 25 min - Discovery talks
-* 40 min - Deep-dive talks
-* 3 hours - Workshops
 
 ## Talks
 
-The **Discovery talk** is for the speaker who has found something cool and wants to share it with the world and inspire other developers. There is no question time in this format.
+Talks will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
+They are structured in 30 mins talk + 10 additional minutes for a Q/A session + 5 minutes to switch rooms. Speakers can modify the ratio between the talk and the Q/A session as they like. 
 
-Instead, the **Deep-dive talk** is intended to present and explain a topic that the presenter is an expert on and/or wants to share in more detail. The presenter can use the entire time for the talk or reserve a few minutes for questions.
+## Workshops
+Workshops can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
 
-## Workshop
-
-A workshop is more hands-on. The presenter can engage the audience in a hands-on tutorial on a topic/technology. Attendees may be asked to set up their environment in advance.
-
-We expect at least 20 people to attend all workshops.
 
 ## Topics
 
-RustLab is open to any Rust related topic. Examples include cloud and networking, language and ecosystem, devices and platforms, security. Cross-topic proposals are also welcome.
+RustLab is receptive to proposals on any Go-related subject matter, including but not limited to cloud computing, networking, programming languages, ecosystems, devices, platforms, and security. Additionally, we encourage submissions that span multiple topics.
 
-If you have a particularly interesting talk that doesn't fit into one of the suggested topics, feel free to submit it anyway and we'll be happy to consider it.
+Even if your talk is not strictly Go-related, we encourage you to submit it. We welcome challenging and unconventional proposals!
 
-## We welcome first-time speakers.
-
-In the coming months, we will offer weekly online office hours for all accepted speakers, where you can talk to us and ask your questions directly.
-
-We will offer 1 to 1 rehearsals, either online or in person at the Develer offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
-
-## After you have sent your proposal
-
-We'll review your proposal as soon as possible and give you some feedback.
-
-Let's make a great conference together!
-
----
-
-### Additional Information
-
-Please, write us any special request or ask for clarification about anything.
-
----
 
 ### CFP Notes
 
@@ -143,48 +117,72 @@ All presentations will be in English.
 
 ## Content Guidelines
 
+We would like our speakers to present **original content**. If your talk has been presented at another conference, please indicate this in your submission.
+
 We expect a common baseline of respectful tone from everyone (see the Code of Conduct for more details).
 
-Presenters may include a company logo on the introduction slide only. Talks about commercial products are allowed as long as they focus on the technical aspect.
-
+Presenters can include a company logo **on the introduction slide only**. Talks about commercial products are allowed as long as they focus on the technical aspect.
 If you would like to speak about your company's product with more freedom, please consider giving a **sponsored talk**. You can contact us for more information at sponsors@rustlab.it.
 
+Given that we have only one slot per day allocated for sponsored talks, please consider that the likelihood of your sponsored talk being featured on the schedule is lower than that of a regular talk.
 
-### Which types of talks will you accept?
+We welcome first-time speakers
 
-- Discovery talk (25 min)
-- Deep-dive talk (40 min)
-- Workshop (3 hours)
+In the coming months, we will offer weekly online office hours for all accepted speakers, where you can talk to us and ask your questions directly.
 
+We will offer 1 to 1 rehearsals, either online or in person at the Develer offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
 
-### Tags
+After you have sent your proposal
 
-...
-
-## Travel
-
-### Do you offer travel assistance?
-
-No
-
----
-
-### If yes, what is your policy?
-
-Accepted speakers will have a reserved room at the venue hotel for the 2 days of the conference (3 days for workshop speakers). 
-
-## Environmental commitment
-
-We are focusing even more on our planet and the environmental emergency. Thanks to our partner [Treedom](https://www.treedom.net), we'll be growing a small forest as part of the RustLab + GoLab 2024 CO2 offsetting initiative.
+We'll review your proposal as soon as possible and give you some feedback.
 
 
-### Rating Style
+## General advice
+
+RustLab receives a lot of proposals, so the team must make a choice. We will review the proposals based on the selection criteria below, please ensure your talk or workshop meet all of them. 
+
+Write a presentation that is long enough to let us understand what’s the goal you want to achieve with the talk, that you have real practical experience on the topic, that you discovered new things that are valuable to share with the community. Moreover please ensure your proposal matches the conference topics and that you’re able to present your talk in the given time slot.
+
+A typical structure of your proposal may be:
+
+_[title/outline]_
+Please not too long: it would be nice if it could fit in a tweet.
+Remember also that the schedule should be readable on smartphones too.
+
+_[kind of session]_
+The kind of session your presentation can apply to (choose among talk, half-day workshop or whole-day workshop)
+
+_[level]_
+Please specify the level of the audience your presentation is addressed to (choose from Introductory and Overview, Intermediate, Advanced and Expert)
+
+_[abstract]_
+This is how your session will be described to the attendees in our schedule. So please be concise on what you are talking about but also try to spice up the interest of your audience by giving them evaluable reasons to attend your presentation.
+
+In case you are making a proposal for a workshop, you may want to specify some technical requirements that your audience should meet to ensure a satisfying experience, such as some devices (a laptop) or a certain version of some software installed on their computer.
 
 
-Five Star (scalar)
+## Ticketing
+
+If you submit a talk or workshop proposal you will be allowed to get your ticket at Early Bird price. In case your proposal may be rejected, we will send you a **discount code to get a Regular ticket for the price of an Early Bird one**. Please make sure to **purchase your ticket before the Regular fare deadline** (September 15th, 2025, at 12 PM, CET) otherwise the discount code won’t apply properly!
 
 
-### Profile Submission Settings
 
 
-no Shirt Size
+## **IMPORTANT: Visa documentation**
+
+According to the Italian Laws, **we are not authorized to produce a document in support of people requesting a business visa for coming to speak to our conferences**. You must request a simple touristic visa and the only document we can produce in support is a declaration you will attend our conference and you will stay in the venue hotel in the conference period.
+Please check if you can get your visa in your country in time for the conference before submitting your proposal.
+
+
+## Benefits for speakers
+
+If your talk is accepted, congrats: you will be officially a RustLab 2026 speaker! 
+
+This grants you a free **Premium ticket** for the conference (free access to all talks and workshops) and free access to the social dinner.
+[1] Plus, we also offer a room at the Grand Hotel Mediterraneo (RustLab’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
+
+We regret that **we can only cover accommodation**; travel expenses are not reimbursed.
+
+
+
+Let's have a great conference together!

--- a/rustlab/call-for-proposals.md
+++ b/rustlab/call-for-proposals.md
@@ -41,7 +41,7 @@ November 1-3, 2026
 ### Event Description
 
 
-RustLab is a comprehensive conference on Rust programming that started in 2015, organized by developers for developers.
+RustLab is a comprehensive conference on Rust programming that started in 2019, organized by developers for developers.
 Since 2022, we have held RustLab and GoLab as a co-located conference, but this year they are back-to-back with a 1-day overlap.
 It is organized by Develer, a software company based in Florence, Italy.
 
@@ -88,7 +88,7 @@ No
 
 ### Call for Proposals
 
-RustLab is a comprehensive conference on the Go programming language, established in 2015 and organized by Develer, a software company based in Bologna, Italy. Designed by developers for developers, RustLab brings together experts and enthusiasts to share knowledge and innovation.
+RustLab is a comprehensive conference on the Rust programming language, established in 2015 and organized by Develer, a software company based in Florence, Italy. Designed by developers for developers, RustLab brings together experts and enthusiasts to share knowledge and innovation.
 
 RustLab will be an in-person event. In this edition you will find talks and workshops.
 
@@ -104,9 +104,9 @@ Workshops can be 3 or 6 hours long, focusing on practical case studies in an int
 
 ## Topics
 
-RustLab is receptive to proposals on any Go-related subject matter, including but not limited to cloud computing, networking, programming languages, ecosystems, devices, platforms, and security. Additionally, we encourage submissions that span multiple topics.
+RustLab is receptive to proposals on any Rust-related subject matter, including but not limited to cloud computing, networking, programming languages, ecosystems, devices, platforms, and security. Additionally, we encourage submissions that span multiple topics.
 
-Even if your talk is not strictly Go-related, we encourage you to submit it. We welcome challenging and unconventional proposals!
+Even if your talk is not strictly Rust-related, we encourage you to submit it. We welcome challenging and unconventional proposals!
 
 
 ### CFP Notes
@@ -178,11 +178,10 @@ Please check if you can get your visa in your country in time for the conference
 
 If your talk is accepted, congrats: you will be officially a RustLab 2026 speaker! 
 
-This grants you a free **Premium ticket** for the conference (free access to all talks and workshops) and free access to the social dinner.
-[1] Plus, we also offer a room at the Grand Hotel Mediterraneo (RustLab’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
+This grants you a free **Premium ticket** for the RustLab conference as well as for GoLab (free access to all talks and workshops) and free access to the social dinner.
+
+Plus, we also offer a room at the Grand Hotel Mediterraneo (RustLab’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
 
 We regret that **we can only cover accommodation**; travel expenses are not reimbursed.
-
-
 
 Let's have a great conference together!

--- a/rustlab/call-for-proposals.md
+++ b/rustlab/call-for-proposals.md
@@ -41,19 +41,15 @@ November 1-3, 2026
 ### Event Description
 
 
-RustLab is a comprehensive conference on Rust programming that started in 2019, organized by developers for developers.
-Since 2022, we have held RustLab and GoLab as a co-located conference, but this year they are back-to-back with a 1-day overlap.
-It is organized by Develer, a software company based in Florence, Italy.
+**RustLab** is a comprehensive conference on **Rust** programming that started in 2019, organized by **Develer**, a software company based in Florence, Italy. Designed by developers for developers, RustLab brings together experts and enthusiasts to share knowledge and innovation.
 
-RustLab will be an **in-person event**. In this edition you will find talks and workshops.
+RustLab will be an **in-person event**. In this edition you will find **talks** and workshops.
 
-We'll have two types of talks, a shorter one, the **25 min Discovery** talk, and a longer one, the **40 min Deep-dive** talk.
+**Talks** will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
 
-The Discovery talk is for the speaker who has found something cool and wants to share it with the world and inspire other developers.
+They are structured in 30 mins talk + 10 additional minutes for a Q/A session + 5 minutes to switch rooms. Speakers can modify the ratio between the talk and the Q/A session as they like. 
 
-Instead, the Deep-dive talk is intended to present and explain a topic in which the speaker is an expert. 
-
-The workshops are 3 hours long and focus on practical case studies.
+**Workshops** can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
 
 ---
 
@@ -88,18 +84,19 @@ No
 
 ### Call for Proposals
 
-RustLab is a comprehensive conference on the Rust programming language, established in 2015 and organized by Develer, a software company based in Florence, Italy. Designed by developers for developers, RustLab brings together experts and enthusiasts to share knowledge and innovation.
+**RustLab** is a comprehensive conference on **Rust** programming that started in 2019, organized by **Develer**, a software company based in Florence, Italy. Designed by developers for developers, RustLab brings together experts and enthusiasts to share knowledge and innovation.
 
-RustLab will be an in-person event. In this edition you will find talks and workshops.
+RustLab will be an **in-person event**. In this edition you will find **talks** and workshops.
 
 
 ## Talks
 
-Talks will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
+**Talks** will last 45 minutes and can either present and explain a topic of expertise or showcase something innovative to inspire other developers.
+
 They are structured in 30 mins talk + 10 additional minutes for a Q/A session + 5 minutes to switch rooms. Speakers can modify the ratio between the talk and the Q/A session as they like. 
 
 ## Workshops
-Workshops can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
+**Workshops** can be 3 or 6 hours long, focusing on practical case studies in an interactive format.
 
 
 ## Topics
@@ -113,7 +110,7 @@ Even if your talk is not strictly Rust-related, we encourage you to submit it. W
 
 ## Language
 
-All presentations will be in English.
+All presentations will be in **English**.
 
 ## Content Guidelines
 
@@ -121,20 +118,22 @@ We would like our speakers to present **original content**. If your talk has bee
 
 We expect a common baseline of respectful tone from everyone (see the Code of Conduct for more details).
 
-Presenters can include a company logo **on the introduction slide only**. Talks about commercial products are allowed as long as they focus on the technical aspect.
-If you would like to speak about your company's product with more freedom, please consider giving a **sponsored talk**. You can contact us for more information at sponsors@rustlab.it.
+Presenters **can include a company logo on the introduction slide only**. Talks about commercial products are allowed as long as they focus on the technical aspect.
+
+If you would like to speak about your company's product with more freedom, please consider giving a **sponsored talk**. You can contact us for more information at [sponsors@rustlab.it](mailto:sponsors@rustlab.it).
 
 Given that we have only one slot per day allocated for sponsored talks, please consider that the likelihood of your sponsored talk being featured on the schedule is lower than that of a regular talk.
 
-We welcome first-time speakers
+### After you have sent your proposal
+
+We'll review your proposal as soon as possible and give you some feedback.
+
+### We welcome first-time speakers
 
 In the coming months, we will offer weekly online office hours for all accepted speakers, where you can talk to us and ask your questions directly.
 
-We will offer 1 to 1 rehearsals, either online or in person at the Develer offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
+We will offer 1 to 1 rehearsals, either online or in person at the **Develer** offices (Calenzano, near Florence), where you can practice your talk and get suggestions.
 
-After you have sent your proposal
-
-We'll review your proposal as soon as possible and give you some feedback.
 
 
 ## General advice
@@ -150,27 +149,31 @@ Please not too long: it would be nice if it could fit in a tweet.
 Remember also that the schedule should be readable on smartphones too.
 
 _[kind of session]_
-The kind of session your presentation can apply to (choose among talk, half-day workshop or whole-day workshop)
+The kind of session your presentation can apply to (choose among *talk*, *half-day workshop* or *whole-day workshop*)
 
 _[level]_
-Please specify the level of the audience your presentation is addressed to (choose from Introductory and Overview, Intermediate, Advanced and Expert)
+Please specify the level of the audience your presentation is addressed to (choose from *Introductory and Overview*, *Intermediate*, *Advanced* and *Expert*)
 
 _[abstract]_
 This is how your session will be described to the attendees in our schedule. So please be concise on what you are talking about but also try to spice up the interest of your audience by giving them evaluable reasons to attend your presentation.
 
-In case you are making a proposal for a workshop, you may want to specify some technical requirements that your audience should meet to ensure a satisfying experience, such as some devices (a laptop) or a certain version of some software installed on their computer.
+In case you are making a proposal for a workshop, you may want to specify some **technical requirements** that your audience should meet to ensure a satisfying experience, such as some devices (a laptop) or a certain version of some software installed on their computer.
 
 
 ## Ticketing
 
-If you submit a talk or workshop proposal you will be allowed to get your ticket at Early Bird price. In case your proposal may be rejected, we will send you a **discount code to get a Regular ticket for the price of an Early Bird one**. Please make sure to **purchase your ticket before the Regular fare deadline** (September 15th, 2025, at 12 PM, CET) otherwise the discount code won’t apply properly!
+Submitting a talk or workshop proposal allows you to get an Early Bird ticket price. If your proposal is rejected, we’ll send you a **discount code to buy a Regular ticket at the Early Bird price.** Please make sure to **purchase your ticket before the Regular fare deadline ({{regular-fare-deadline}})** otherwise the discount code won’t apply properly!
 
+Of course, in case you'll be appointed as a speaker, you'll get a **free Speaker ticket** which is equivalent of a **Premium** one. In case you already bought a ticket for the conference you may choose between reassigning that ticket to somebody else or have it refunded.
+
+This year GoLab and Rustlab will be held together (same days in the same venue), so **your ticket will be valid to attend both conferences** as well!
 
 
 
 ## **IMPORTANT: Visa documentation**
 
-According to the Italian Laws, **we are not authorized to produce a document in support of people requesting a business visa for coming to speak to our conferences**. You must request a simple touristic visa and the only document we can produce in support is a declaration you will attend our conference and you will stay in the venue hotel in the conference period.
+According to the Italian Laws, **we are not authorized to produce a document in support of people requesting a business visa for coming to speak to our conferences**. You must request a simple **touristic visa** and the only document we can produce in support is a declaration you will attend our conference and you will stay in the venue hotel in the conference period.
+
 Please check if you can get your visa in your country in time for the conference before submitting your proposal.
 
 
@@ -178,10 +181,13 @@ Please check if you can get your visa in your country in time for the conference
 
 If your talk is accepted, congrats: you will be officially a RustLab 2026 speaker! 
 
-This grants you a free **Premium ticket** for the RustLab conference as well as for GoLab (free access to all talks and workshops) and free access to the social dinner.
+This grants you a **free Speaker ticket** for the conference (free access to all talks and workshops) and free access to the social dinner.
 
-Plus, we also offer a room at the Grand Hotel Mediterraneo (RustLab’s venue) for all the conference duration (2 nights for talks, 3 nights for workshops presenters).
+Plus, we also offer **a room'* at the {{conf-venue}} (RustLab’s venue) for all the conference duration** (2 nights for talks, 3 nights for workshops presenters).
 
-We regret that **we can only cover accommodation**; travel expenses are not reimbursed.
+We regret that _**we can only cover accommodation**_; travel expenses are not reimbursed.
+
+'* = the room we offer is a double room for a single use. In case you need different requirements, please e-mail us at [info@rustlab.it](mailto:info@rustlab.it) and we will help you out to meet them. This will be the lodging offer covered by the conference organization anyway: in case of further extras (more nights, bigger room, etc.) they will be on your charge.
 
 Let's have a great conference together!
+

--- a/rustlab/code_of_conduct.md
+++ b/rustlab/code_of_conduct.md
@@ -44,7 +44,9 @@ If the matter is especially urgent, please contact any of these individuals or e
 
 - Mena Marotta (she/her)
 - Matteo Bertini (he/him)
-- Niccolò Pieretti (he/him)
+- Aurélien Rainone (he/him)
+- Federico Guerinoni (he/him)
+- Pietro Lorefice (he/him)
 
 
 The code of conduct team is empowered to, amongst other things:


### PR DESCRIPTION
Regenerate for GoLab/RustLab 2026

Added feature:
Allow to have conference-specific or conference-only template. For example if a file is called `golab.foobar.md` then it would only be generated when doing `python generate.py golab` and skipped otherwise